### PR TITLE
Remove upper bound on websockets version constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   entry_points:
     - marimo = marimo._cli.cli:main
-  number: 0
+  number: 1
   skip: true  # [python_impl == "pypy"]
 
 requirements:
@@ -35,7 +35,7 @@ requirements:
     - typing-extensions >=4.4.0  # [py<310]
     - uvicorn >=0.22.0
     - starlette >=0.26.1,!=0.36.0
-    - websockets >=10,<13
+    - websockets >=10
     - docutils >=0.17.0
     - psutil >=5.0
     - itsdangerous >=2


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Closes #158 
